### PR TITLE
Support changes for Tauri 2.0

### DIFF
--- a/tauri-plugin-htmx.js
+++ b/tauri-plugin-htmx.js
@@ -1,4 +1,4 @@
-const {invoke} = window.__TAURI__.tauri;
+import {invoke} from "@tauri-apps/api/core";
 
 const COMMAND_PREFIX = "command:";
 


### PR DESCRIPTION
Both Tauri 1.0 and 2.0 now use this syntax for importing Tauri functions, but 2.0 will not work without it. Using this change I was able to get a Tauri and HTMX demo working on Android.